### PR TITLE
(GH-61) Handle when $chocoInstallLocation is null

### DIFF
--- a/Tasks/installer/installer.ps1
+++ b/Tasks/installer/installer.ps1
@@ -3,10 +3,12 @@
 Trace-VstsEnteringInvocation $MyInvocation
 
 $chocoInstallLocation = [Environment]::GetEnvironmentVariable("ChocolateyInstall", "Machine")
-if(-not (Test-Path $chocoInstallLocation)) {
+if($chocoInstallLocation -and -not (Test-Path $chocoInstallLocation)) {
     Write-Output "Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables..."
     $chocoInstallLocation = [Environment]::GetEnvironmentVariable("ChocolateyInstall", "User")
 }
+
+Write-Verbose "chocoInstallLocation: $chocoInstallLocation"
 
 $chocoExe = "$chocoInstallLocation\choco.exe"
 


### PR DESCRIPTION
- If environment variable isn't found, then it is set to null, so we check this before we try and call Test-Path

Fixes #61 