### PR TITLE
(GH-64) Handle when $chocoInstallLocation is null (in chocolatey.ps1)

### DIFF
--- a/Tasks/chocolatey/chocolatey.ps1
+++ b/Tasks/chocolatey/chocolatey.ps1
@@ -5,11 +5,13 @@ Trace-VstsEnteringInvocation $MyInvocation
 
 try {
   $chocoInstallLocation = [Environment]::GetEnvironmentVariable("ChocolateyInstall", "Machine")
-	if(-not (Test-Path $chocoInstallLocation)) {
+	if($chocoInstallLocation -and -not (Test-Path $chocoInstallLocation)) {
 		Write-Output "Environment variable 'ChocolateyInstall' was not found in the system variables. Attempting to find it in the user variables..."
 		$chocoInstallLocation = [Environment]::GetEnvironmentVariable("ChocolateyInstall", "User")
 	}
 
+  Write-Verbose "chocoInstallLocation: $chocoInstallLocation"
+  
 	$chocoExe = "$chocoInstallLocation\choco.exe"
 
 	if (-not (Test-Path $chocoExe)) {


### PR DESCRIPTION
If environment variable isn't found, then it is set to null, so we check this before we try and call Test-Path

Fixes #64 
